### PR TITLE
fix(config): remove duplicate passwordEncoder bean from AppConfig

### DIFF
--- a/src/main/java/com/insi/ticketplace/config/AppConfig.java
+++ b/src/main/java/com/insi/ticketplace/config/AppConfig.java
@@ -1,0 +1,12 @@
+package com.insi.ticketplace.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AppConfig {
+    // Ce fichier peut accueillir d'autres beans généraux plus tard
+    // (ex: ModelMapper, ObjectMapper custom, etc.)
+}


### PR DESCRIPTION
remove duplicate passwordEncoder bean from AppConfig - kept in SecurityConfig